### PR TITLE
Add critical condition for tractionBattery, add hydrogentankinfo

### DIFF
--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -149,6 +149,21 @@
 				"temperature": {
 					"type": "integer",
 					"additionalProperties": false
+				},
+				"criticalCondition": {
+					"type": "boolean",
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"HydrogenTankInfo": {
+			"description": "This type represents information regarding a hydrogen tank.",
+			"type": "object",
+			"properties": {
+				"criticalCondition": {
+					"type": "boolean",
+					"additionalProperties": false
 				}
 			},
 			"additionalProperties": false
@@ -258,6 +273,9 @@
 				},
 				"tractionBatteryInfo": {
 					"$ref": "#/definitions/TractionBatteryInfo"
+				},
+				"hydrogenTankInfo": {
+					"$ref": "#/definitions/HydrogenTankInfo"
 				},
 				"vehicleStatusInfo": {
 					"$ref": "#/definitions/VehicleStatusInfo"

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -151,7 +151,7 @@
 					"additionalProperties": false
 				},
 				"criticalCondition": {
-					"type": "boolean",
+					"type": "integer",
 					"additionalProperties": false
 				}
 			},
@@ -162,7 +162,7 @@
 			"type": "object",
 			"properties": {
 				"criticalCondition": {
-					"type": "boolean",
+					"type": "integer",
 					"additionalProperties": false
 				}
 			},

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -427,6 +427,9 @@
 				"chargingPointId": {
 					"$ref": "#/definitions/UniqueIdentifier"
 				},
+				"vehicleId": {
+					"$ref": "#/definitions/VehicleIdentifier"
+				},
 				"chargingPointStatus": {
 					"$ref": "#/definitions/ChargingPointStatus"
 				},

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -453,9 +453,6 @@
 				"chargingPointFaultInfo": {
 					"$ref": "#/definitions/ChargingPointFaultInfo"
 				},
-				"vehicleInfo": {
-					"$ref": "#/definitions/VehicleInfo"
-				},
 				"chargingProcessInfo": {
 					"$ref": "#/definitions/ChargingProcessInfo"
 				},
@@ -522,6 +519,14 @@
 					"minItems": 1,
 					"items": {
 						"$ref": "#/definitions/ChargingStationInfo"
+					},
+					"additionalProperties": false
+				},
+				"vehicleInfoList": {
+					"type": "array",
+					"minItems": 0,
+					"items": {
+						"$ref": "#/definitions/VehicleInfo"
 					},
 					"additionalProperties": false
 				}

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -150,7 +150,7 @@
 					"type": "integer",
 					"additionalProperties": false
 				},
-				"criticalCondition": {
+				"status": {
 					"type": "integer",
 					"additionalProperties": false
 				}
@@ -161,7 +161,7 @@
 			"description": "This type represents information regarding a hydrogen tank.",
 			"type": "object",
 			"properties": {
-				"criticalCondition": {
+				"status": {
 					"type": "integer",
 					"additionalProperties": false
 				}

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -427,9 +427,6 @@
 				"chargingPointId": {
 					"$ref": "#/definitions/UniqueIdentifier"
 				},
-				"vehicleId": {
-					"$ref": "#/definitions/VehicleIdentifier"
-				},
 				"chargingPointStatus": {
 					"$ref": "#/definitions/ChargingPointStatus"
 				},
@@ -455,6 +452,9 @@
 				},
 				"chargingPointFaultInfo": {
 					"$ref": "#/definitions/ChargingPointFaultInfo"
+				},
+				"vehicleInfo": {
+					"$ref": "#/definitions/VehicleInfo"
 				},
 				"chargingProcessInfo": {
 					"$ref": "#/definitions/ChargingProcessInfo"
@@ -522,14 +522,6 @@
 					"minItems": 1,
 					"items": {
 						"$ref": "#/definitions/ChargingStationInfo"
-					},
-					"additionalProperties": false
-				},
-				"vehicleInfoList": {
-					"type": "array",
-					"minItems": 0,
-					"items": {
-						"$ref": "#/definitions/VehicleInfo"
 					},
 					"additionalProperties": false
 				}


### PR DESCRIPTION
### Aufnahme der kritischen Information zur Batterie und zum Wasserstofftank

**Datenpunkt: Wasserstoffleck**
- VDV 261
  - Parameter: `h2_stat`
  - Datentyp: signed integer
  - Wertebereich: -1 (SNA), 0 (okay), 1 (not okay)
- VDV 463
  - Parameter: `VehicleInfo.hydrogenTankInfo.status`
  - Wertebereich: Ganzzahl (keine Beschränkung)

**Datenpunkt: Batteriestatus**
- VDV 261 
  - Parameter: `bat_stat`
  - Datentyp: signed integer
  - Wertebereich: -1 (SNA), 0 (okay), 1 (not okay), 2 (critical)
- VDV 463
  - Parameter: `VehicleInfo.TractionBatteryInfo.status`
  - Wertebereich: Ganzzahl (keine Beschränkung)

